### PR TITLE
Fix 'and endless loop' typo in usage

### DIFF
--- a/Source_Code/BasTo6809.bas
+++ b/Source_Code/BasTo6809.bas
@@ -471,7 +471,7 @@ If count = 0 Then
     Print "       -fxxxx    - Where xxxx is the font name used for printing to the PMODE 4 screen (default is Arcade)"
     Print "                   Look in folder Basic_Includes/Graphic_Screen_Fonts to see font names available"
     Print "       -a        - Makes the program autostart after it is LOADed on the CoCo"
-    Print "       -r        - At the end of the program the compiler will try to return to BASIC, default is to do and endless loop"
+    Print "       -r        - At the end of the program the compiler will try to return to BASIC, default is to do an endless loop"
     Print "       -h        - Show this help message"
     Print
     Print "See Manual.pdf file for more help"


### PR DESCRIPTION
Very minor typo fix.  I just started using BasTo6809.

Just wondering if you are open to fixes.

Also Thanks for Defender and the rest...